### PR TITLE
Replace mixin semi-colons with commas

### DIFF
--- a/tasks/lib/replacements/@include.js
+++ b/tasks/lib/replacements/@include.js
@@ -5,6 +5,8 @@
  */
 module.exports = {
   pattern: /(\s+)\.([\w\-]*)\s*\((.*)\);/gi,
-  replacement: '$1@include $2($3);',
+  replacement: function(match, indent, $2, $3) {
+    return indent + '@include ' + $2 + '(' + $3.replace(/;/g, ',') + ');';
+  },
   order: 2
 };

--- a/tasks/lib/replacements/@mixin.js
+++ b/tasks/lib/replacements/@mixin.js
@@ -5,6 +5,8 @@
  */
 module.exports = {
   pattern: /\.([\w\-]*)\s*\((.*)\)\s*\{/gi,
-  replacement: '@mixin $1($2){',
+  replacement: function (match, $1, $2) {
+    return '@mixin ' + $1 + '(' + $2.replace(/;/g, ',') + ') {';
+  },
   order: 2
 };


### PR DESCRIPTION
In LESS, semi-colon separators between mixin parameters are valid (for example, here in [Bootstrap](https://github.com/twbs/bootstrap/blob/v3.3.6/less/buttons.less#L20)) but is SASS they are not.

By using functions we can replace them without many changes.

I can't tell what case [@include_nested.js](https://github.com/duvillierA/grunt-less-to-sass/blob/master/tasks/lib/replacements/%40include_nested.js) is covering that @include.js doesn't, so I'm not sure if it applies here.

TODO:
- [ ] Determine if @include_nested.js needs to be changed
