### PR TITLE
Fix Lodash Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "engines": {
     "node": ">=0.10.28"
   },
-  "dependencies": {
-    "lodash": "^4.17.15"
-  },
+  "dependencies": {},
   "devDependencies": {
     "chai": "~4.2.0",
     "grunt": "~1.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "engines": {
-    "node": ">=0.10.28"
+    "node": ">=0.10.29"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/duvillierA/grunt-less-to-sass.git"
+    "url": "git@github.com:duvillierA/grunt-less-to-sass.git"
   },
   "bugs": {
     "url": "https://github.com/duvillierA/grunt-less-to-sass/issues"
@@ -21,28 +21,22 @@
     }
   ],
   "engines": {
-    "node": ">=0.10.29"
+    "node": ">=0.10.28"
   },
   "dependencies": {
-    "lodash": "~3.0.1"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "chai": "~1.10.0",
-    "grunt": "~0.4.5",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-jsbeautifier": "~0.2.7",
-    "grunt-jsonlint": "~1.0.4",
-    "grunt-mocha-test": "~0.12.4",
-    "grunt-sass": "0.16.1",
-    "load-grunt-config": "~0.12.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:duvillierA/grunt-less-to-sass.git"
-  },
-  "engines": {
-    "node": ">=0.10.28"
+    "chai": "~4.2.0",
+    "grunt": "~1.0.4",
+    "grunt-contrib-clean": "~2.0.0",
+    "grunt-contrib-jshint": "~2.1.0",
+    "grunt-jsbeautifier": "~0.2.13",
+    "grunt-jsonlint": "~2.0.0",
+    "grunt-mocha-test": "~0.13.3",
+    "grunt-sass": "3.1.0",
+    "load-grunt-config": "~3.0.0",
+    "mocha": "^6.2.0"
   },
   "keywords": [
     "grunt",
@@ -58,6 +52,6 @@
   ],
   "scripts": {
     "start": "grunt",
-    "test": "DEBUG= mocha --bail --timeout 100 'test/unit/**/*.test.js'"
+    "test": "mocha --bail --timeout 100 'test/unit/**/*.test.js'"
   }
 }

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-  _ = require('lodash'),
   dir = __dirname + '/replacements/';
 
 var replacements = function (options) {
@@ -11,7 +10,11 @@ var replacements = function (options) {
     return require(dir + filename);
   }).concat(options.replacements);
 
-  return _.sortBy(results, 'order');
+  results.sort(function (a, b) {
+    return a.order - b.order;
+  });
+
+  return results;
 };
 
 module.exports = replacements;

--- a/tasks/lib/replacements/@include_nested.js
+++ b/tasks/lib/replacements/@include_nested.js
@@ -8,5 +8,5 @@
 module.exports = {
   pattern: /(\s*)\#([\w\-]*)\s*>\s*\@include\s+(.*);/gi,
   replacement: '$1@include $2-$3;',
-  order: 2
+  order: 3
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const fs = require("fs"),
+var fs = require("fs"),
   assert = require("chai").assert,
   lib = require("../tasks/lib/index");
 
-const replacements = lib({
+var replacements = lib({
   excludes: [],
   replacements: []
 });
@@ -17,10 +17,18 @@ function transform(filepath) {
     });
 }
 
-describe("Fixtures to Expected", () => {
+it("replacements in proper order", function () {
+  var curr = 0;
+  for (var i = 0; i < replacements.length; i++) {
+    assert.isTrue(curr <= replacements[i].order);
+    curr = replacements[i].order;
+  }
+});
+
+describe("test fixtures to expected", function () {
   fs.readdirSync("test/fixtures/").forEach(file => {
     it("should properly convert " + file, function() {
-      const expectedFile = "test/expected/" + file.replace(".less", ".scss");
+      var expectedFile = "test/expected/" + file.replace(".less", ".scss");
       assert.isTrue(fs.existsSync(expectedFile, "utf8"));
       assert.equal(
         fs.readFileSync(expectedFile, "utf8"),


### PR DESCRIPTION
Lodash has a [recently discovered vulnerability](https://snyk.io/vuln/SNYK-JS-LODASH-450202) that is easily remedied by updating to version 4.17.12 or higher. I used [npm-check-updates](https://www.npmjs.com/package/npm-check-updates) to update all the dependencies. [Running the tests](https://github.com/duvillierA/grunt-less-to-sass/pull/9) showed that this does not affect functionality.